### PR TITLE
Xcode 14 building flags added

### DIFF
--- a/ios_build_settings_renderer/models.py
+++ b/ios_build_settings_renderer/models.py
@@ -38,7 +38,10 @@ class XCConfig(XCConfigTuple):
                 XCConfigOption.swift_optimization_level,
                 XCConfigOption.swift_compilation_mode,
                 XCConfigOption.assetcatalog_compiler_optimization,
-                XCConfigOption.other_swift_flags
+                XCConfigOption.other_swift_flags,
+                XCConfigOption.deployment_postprocessing,
+                XCConfigOption.strip_installed_product,
+                XCConfigOption.stripflags
             ])
         )
 
@@ -122,6 +125,18 @@ class XCConfigOption(XCConfigOptionTuple):
     @staticmethod
     def other_swift_flags(selectors_dict):
         return XCConfigOption.__from_key_and_value_based_on_value_in_selectors("OTHER_SWIFT_FLAGS", "$(inherited) -Xfrontend -warn-long-expression-type-checking=500 -Xfrontend -warn-long-function-bodies=500 -Xfrontend -enable-actor-data-race-checks", "$(inherited)", selectors_dict)
+
+    @staticmethod
+    def deployment_postprocessing(selectors_dict):
+        return XCConfigOption.__from_key_and_value_based_on_value_in_selectors("DEPLOYMENT_POSTPROCESSING", "YES", "NO", selectors_dict)
+
+    @staticmethod
+    def strip_installed_product(selectors_dict):
+        return XCConfigOption.__from_key_and_value_based_on_value_in_selectors("STRIP_INSTALLED_PRODUCT", "YES", "NO", selectors_dict)
+
+    @staticmethod
+    def stripflags(selectors_dict):
+        return XCConfigOption.__from_key_and_value_based_on_value_in_selectors("STRIPFLAGS", "-rSTx", "", selectors_dict)
 
     @staticmethod
     def __from_key_and_value_based_on_value_in_selectors(key, value_if_contains, otherwise_value,

--- a/ios_build_settings_renderer/models.py
+++ b/ios_build_settings_renderer/models.py
@@ -128,15 +128,15 @@ class XCConfigOption(XCConfigOptionTuple):
 
     @staticmethod
     def deployment_postprocessing(selectors_dict):
-        return XCConfigOption.__from_key_and_value_based_on_value_in_selectors("DEPLOYMENT_POSTPROCESSING", "YES", "NO", selectors_dict)
+        return XCConfigOption.__from_key_and_value_based_on_value_in_selectors("DEPLOYMENT_POSTPROCESSING", "YES", "NO", selectors_dict, "Release")
 
     @staticmethod
     def strip_installed_product(selectors_dict):
-        return XCConfigOption.__from_key_and_value_based_on_value_in_selectors("STRIP_INSTALLED_PRODUCT", "YES", "NO", selectors_dict)
+        return XCConfigOption.__from_key_and_value_based_on_value_in_selectors("STRIP_INSTALLED_PRODUCT", "YES", "NO", selectors_dict, "Release")
 
     @staticmethod
     def stripflags(selectors_dict):
-        return XCConfigOption.__from_key_and_value_based_on_value_in_selectors("STRIPFLAGS", "-rSTx", "", selectors_dict)
+        return XCConfigOption.__from_key_and_value_based_on_value_in_selectors("STRIPFLAGS", "-rSTx", "", selectors_dict, "Release")
 
     @staticmethod
     def __from_key_and_value_based_on_value_in_selectors(key, value_if_contains, otherwise_value,

--- a/ios_build_settings_renderer/models.py
+++ b/ios_build_settings_renderer/models.py
@@ -40,7 +40,7 @@ class XCConfig(XCConfigTuple):
                 XCConfigOption.assetcatalog_compiler_optimization,
                 XCConfigOption.other_swift_flags,
                 XCConfigOption.deployment_postprocessing,
-                XCConfigOption.strip_installed_product,
+                XCConfigOption.strip_linked_product,
                 XCConfigOption.stripflags
             ])
         )
@@ -131,8 +131,8 @@ class XCConfigOption(XCConfigOptionTuple):
         return XCConfigOption.__from_key_and_value_based_on_value_in_selectors("DEPLOYMENT_POSTPROCESSING", "YES", "NO", selectors_dict, "Release")
 
     @staticmethod
-    def strip_installed_product(selectors_dict):
-        return XCConfigOption.__from_key_and_value_based_on_value_in_selectors("STRIP_INSTALLED_PRODUCT", "YES", "NO", selectors_dict, "Release")
+    def strip_linked_product(selectors_dict):
+        return XCConfigOption.__from_key_and_value_based_on_value_in_selectors("STRIP_LINKED_PRODUCT", "YES", "NO", selectors_dict, "Release")
 
     @staticmethod
     def stripflags(selectors_dict):


### PR DESCRIPTION
## Добавление флагов сборки в генератор конфигов в рамках миграции на Xcode 14

- Добавил флаги `DEPLOYMENT_POSTPROCESSING`, `STRIP_INSTALLED_PRODUCT` и `STRIPFLAGS`